### PR TITLE
Add requests.Sessions

### DIFF
--- a/theguardian/theguardian_content.py
+++ b/theguardian/theguardian_content.py
@@ -16,6 +16,7 @@ class Content:
         :return: None
         """
 
+        self.session = requests.Session()
         self.__headers = {
             "api-key": api,
             "format": "json"
@@ -43,7 +44,7 @@ class Content:
         else:
             headers.update(self.__headers)
 
-        res = requests.get(self.base_url, headers)
+        res = self.session.get(self.base_url, headers=headers)
 
         return res
 

--- a/theguardian/theguardian_section.py
+++ b/theguardian/theguardian_section.py
@@ -15,6 +15,7 @@ class Section:
         :return:
         """
 
+        self.session = requests.Session()
         self.__request_response = None
         self.__headers = {
             "api-key": api,
@@ -41,7 +42,7 @@ class Section:
             header = self.__headers
         else:
             header.update(self.__headers)
-        res = requests.get(self.base_url, header)
+        res = self.session.get(self.base_url, headers=header)
 
         return res
 


### PR DESCRIPTION
By creating a Session, requests can reuse a TCP connection. This can speed up the requests to the Guardian API. In my tests this improvement halved the time of every request (only when making multiple requests).