### PR TITLE
test: fix test failures caused by HTTP status codes differences

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -23,7 +23,7 @@ class TestContent(unittest.TestCase):
 
         api_key = "tests"
         res = theguardian_content.Content(api_key).get_request_response()
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, 401)
 
     def test_content_response_header(self):
 

--- a/tests/test_edition.py
+++ b/tests/test_edition.py
@@ -24,7 +24,7 @@ class TestEdition(unittest.TestCase):
         api_key = "tests"
         res = theguardian_edition.Edition(api_key).get_request_response()
 
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, 401)
 
     def test_edition_get_direct_content(self):
 
@@ -50,7 +50,7 @@ class TestEdition(unittest.TestCase):
         res = edition.get_request_response()
         edition_content = edition.get_content_response()
 
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, 401)
         self.assertIn("message", edition_content.keys())
         self.assertEqual("Invalid authentication credentials", edition_content["message"])
 

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -25,7 +25,7 @@ class TestSection(unittest.TestCase):
         api_key = "tests"
         res = theguardian_section.Section(api_key).get_request_response()
 
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, 401)
 
     def test_section_get_direct_content(self):
 
@@ -51,7 +51,7 @@ class TestSection(unittest.TestCase):
         res = section.get_request_response()
         section_content = section.get_content_response()
 
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, 401)
         self.assertIn("message", section_content.keys())
         self.assertEqual("Invalid authentication credentials", section_content["message"])
 

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -24,7 +24,7 @@ class TestTag(unittest.TestCase):
         api_key = "tests"
         res = theguardian_tag.Tag(api_key).get_request_response()
 
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, 401)
 
     def test_tag_get_direct_content(self):
 
@@ -50,7 +50,7 @@ class TestTag(unittest.TestCase):
         res = tag.get_request_response()
         tag_content = tag.get_content_response()
 
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, 401)
         self.assertIn("message", tag_content.keys())
         self.assertEqual("Invalid authentication credentials", tag_content["message"])
 


### PR DESCRIPTION
fixes #14

The tests were failing due to the differences in HTTP response codes. Now, the API server returns `401 Unauthorized` when the API token is incorrect.

## Test results in local

```shell
[theguardian-api-python]  test/replace-403-with-401 (9eb136d) via  v3.11.5
|> python test.py -v
test_content_get_result_with_exception (test_content.TestContent.test_content_get_result_with_exception) ... ok
test_content_response_failure_incorrect_api_key (test_content.TestContent.test_content_response_failure_incorrect_api_key) ... ok
test_content_response_header (test_content.TestContent.test_content_response_header) ... ok
test_content_response_success_correct_details (test_content.TestContent.test_content_response_success_correct_details) ... ok
test_content_results (test_content.TestContent.test_content_results) ... ok
test_content_with_headers (test_content.TestContent.test_content_with_headers) ... ok
test_contents_find_by_id_correct_url (test_content.TestContent.test_contents_find_by_id_correct_url) ... ok
test_contents_find_by_id_incorrect_url (test_content.TestContent.test_contents_find_by_id_incorrect_url) ... ok
test_section_get_references_correct_pages (test_content.TestContent.test_section_get_references_correct_pages) ... ok
test_section_get_references_incorrect_pages (test_content.TestContent.test_section_get_references_incorrect_pages) ... ok
test_edition_get_direct_content (test_edition.TestEdition.test_edition_get_direct_content) ... ok
test_edition_get_indirect_content (test_edition.TestEdition.test_edition_get_indirect_content) ... ok
test_edition_get_indirect_content_invalid_credentials (test_edition.TestEdition.test_edition_get_indirect_content_invalid_credentials) ... ok
test_edition_get_response_section_count (test_edition.TestEdition.test_edition_get_response_section_count) ... ok
test_edition_get_result_with_exception (test_edition.TestEdition.test_edition_get_result_with_exception) ... ok
test_edition_get_result_without_exception (test_edition.TestEdition.test_edition_get_result_without_exception) ... ok
test_edition_response_failure_incorrect_api_key (test_edition.TestEdition.test_edition_response_failure_incorrect_api_key) ... ok
test_edition_response_success_correct_details (test_edition.TestEdition.test_edition_response_success_correct_details) ... ok
test_edition_url (test_edition.TestEdition.test_edition_url) ... ok
test_section_get_direct_content (test_section.TestSection.test_section_get_direct_content) ... ok
test_section_get_indirect_content (test_section.TestSection.test_section_get_indirect_content) ... ok
test_section_get_indirect_content_invalid_credentials (test_section.TestSection.test_section_get_indirect_content_invalid_credentials) ... ok
test_section_get_result_with_exception (test_section.TestSection.test_section_get_result_with_exception) ... ok
test_section_get_result_without_exception (test_section.TestSection.test_section_get_result_without_exception) ... ok
test_section_response_failure_incorrect_api_key (test_section.TestSection.test_section_response_failure_incorrect_api_key) ... ok
test_section_response_success_correct_details (test_section.TestSection.test_section_response_success_correct_details) ... ok
test_section_get_references_correct_pages (test_tag.TestTag.test_section_get_references_correct_pages) ... ok
test_section_get_references_incorrect_pages (test_tag.TestTag.test_section_get_references_incorrect_pages) ... ok
test_tag_get_direct_content (test_tag.TestTag.test_tag_get_direct_content) ... ok
test_tag_get_indirect_content (test_tag.TestTag.test_tag_get_indirect_content) ... ok
test_tag_get_indirect_content_invalid_credentials (test_tag.TestTag.test_tag_get_indirect_content_invalid_credentials) ... ok
test_tag_get_result_with_exception (test_tag.TestTag.test_tag_get_result_with_exception) ... ok
test_tag_get_result_without_exception (test_tag.TestTag.test_tag_get_result_without_exception) ... ok
test_tag_response_failure_incorrect_api_key (test_tag.TestTag.test_tag_response_failure_incorrect_api_key) ... ok
test_tag_response_success_correct_details (test_tag.TestTag.test_tag_response_success_correct_details) ... ok
test_tag_url (test_tag.TestTag.test_tag_url) ... ok

----------------------------------------------------------------------
Ran 36 tests in 37.939s

OK
```